### PR TITLE
Add spider plot option to amp_ordinate + small fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ampvis2
 Type: Package
 Title: Tools for visualising amplicon data
 Description: ampvis2 is a small set of tools that allows effortless visualisation of amplicon data.
-Version: 2.8.11
+Version: 2.8.12
 Authors@R: c(
   person(
     c("Kasper", "Skytte"), "Andersen", 
@@ -68,5 +68,5 @@ Suggests:
     doParallel,
     foreach,
     patchwork
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.3
 Config/testthat/edition: 3

--- a/R/amp_heatmap.R
+++ b/R/amp_heatmap.R
@@ -457,8 +457,9 @@ amp_heatmap <- function(data,
   ## Define the output
   if (!isTRUE(textmap)) {
     ## Make a heatmap style plot
-    heatmap <- ggplot(abund7, aes_string(x = ".Group", y = "Display", label = formatC("Abundance", format = "f", digits = 1))) +
-      geom_tile(aes(fill = Abundance), colour = "white", size = 0.5) +
+    abund7$Abundance_label <- formatC(abund7$Abundance, format="f", digits=1)
+    heatmap <- ggplot(abund7, aes(x = .data[[".Group"]], y = .data[["Display"]], label = Abundance_label)) +
+      geom_tile(aes(fill = Abundance), colour = "white", linewidth = 0.5) +
       theme(
         axis.text.y = element_text(size = 12, color = "black", vjust = 0.4),
         axis.text.x = element_text(size = 10, color = "black", vjust = 0.5, angle = 90, hjust = 1),

--- a/R/amp_ordinate.R
+++ b/R/amp_ordinate.R
@@ -35,7 +35,7 @@
 #' @param sample_label_size Sample labels text size. (\emph{default:} \code{4})
 #' @param sample_label_segment_color Sample labels repel-segment color. (\emph{default:} \code{"black"})
 #' @param sample_shape_by Shape sample points by a variable in the metadata.
-#' @param sample_spider Connect the sample points to their group centroid with lines to create a spider plot, split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to draw the spider plot based on the variable in \code{sample_color_by}. (\emph{default:} \code{FALSE}) Note: Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).
+#' @param sample_spider Connect the sample points to their group centroid with lines to create a spider plot, split by the grouping variable defined by \code{sample_color_by}, or overridden by \code{sample_colorframe} if provided, or simply \code{TRUE} to draw the spider plot based on the same grouping logic. (\emph{default:} \code{FALSE}) Note: Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).
 #' @param sample_colorframe Frame the sample points with a polygon by a variable in the metadata split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to frame the points colored by \code{sample_color_by}. (\emph{default:} \code{FALSE})
 #' @param sample_colorframe_label Label by a variable in the metadata.
 #' @param sample_colorframe_label_size Size of the color frame labels. (\emph{default:} \code{3})
@@ -215,6 +215,10 @@ amp_ordinate <- function(data,
     stop("Ordination cannot be performed on 2 or fewer samples (the number of resulting axes will always be n-1, where n is the number of samples).", call. = FALSE)
   }
 
+  if (is.null(sample_color_by) & !is.logical(sample_spider) & !is.null(sample_spider)) {
+    sample_color_by <- sample_spider
+  }
+  
   if (is.null(sample_color_by) & !is.logical(sample_colorframe) & !is.null(sample_colorframe)) {
     sample_color_by <- sample_colorframe
   }
@@ -571,9 +575,14 @@ amp_ordinate <- function(data,
     if (is.null(sample_color_by) && identical(sample_spider, TRUE)) {
       stop("sample_spider requires sample_color_by or a grouping variable.", call. = FALSE)
     }
-    if (identical(sample_spider, TRUE)) {
-      spider_group <- sample_color_by
-    } else {
+    spider_group <- sample_color_by
+    
+    if (!is.logical(sample_colorframe) && !is.null(sample_colorframe)) {
+      spider_group <- sample_colorframe
+    }
+    
+    # override only if user explicitly passes a variable
+    if (!identical(sample_spider, TRUE) && !is.null(sample_spider)) {
       spider_group <- sample_spider
     }
     
@@ -628,12 +637,12 @@ amp_ordinate <- function(data,
         aes(text = data_plotly)
       )) + # HER
       theme_minimal() +
-      theme(axis.line = element_line(colour = "black", size = 0.5))
+      theme(axis.line = element_line(colour = "black", linewidth = 0.5))
   } else {
     plot <- plot +
       geom_point(size = sample_point_size, alpha = opacity) +
       theme_minimal() +
-      theme(axis.line = element_line(colour = "black", size = 0.5))
+      theme(axis.line = element_line(colour = "black", linewidth = 0.5))
   }
 
   # Only eigenvalue-based ordination methods can be displayed with % on axes

--- a/R/amp_ordinate.R
+++ b/R/amp_ordinate.R
@@ -35,6 +35,7 @@
 #' @param sample_label_size Sample labels text size. (\emph{default:} \code{4})
 #' @param sample_label_segment_color Sample labels repel-segment color. (\emph{default:} \code{"black"})
 #' @param sample_shape_by Shape sample points by a variable in the metadata.
+#' @param sample_spider Connect the sample points to their group centroid with lines to create a spider plot, split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to draw the spider plot based on the variable in \code{sample_color_by}. (\emph{default:} \code{FALSE}) \note{Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).}
 #' @param sample_colorframe Frame the sample points with a polygon by a variable in the metadata split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to frame the points colored by \code{sample_color_by}. (\emph{default:} \code{FALSE})
 #' @param sample_colorframe_label Label by a variable in the metadata.
 #' @param sample_colorframe_label_size Size of the color frame labels. (\emph{default:} \code{3})
@@ -162,6 +163,7 @@ amp_ordinate <- function(data,
                          sample_color_by = NULL,
                          sample_color_order = NULL,
                          sample_shape_by = NULL,
+                         sample_spider = FALSE,
                          sample_colorframe = FALSE,
                          sample_colorframe_label = NULL,
                          sample_colorframe_label_size = 3,
@@ -562,6 +564,50 @@ amp_ordinate <- function(data,
       hulls <- do.call(rbind, splitData)
       plot <- plot + geom_polygon(data = hulls, aes_string(fill = sample_color_by, group = "colorframeGroup"), alpha = 0.2 * opacity)
     }
+  }
+  
+  ##### Spider plot #####
+  if (!identical(sample_spider, FALSE)) {
+    if (is.null(sample_color_by) && identical(sample_spider, TRUE)) {
+      stop("sample_spider requires sample_color_by or a grouping variable.", call. = FALSE)
+    }
+    if (identical(sample_spider, TRUE)) {
+      spider_group <- sample_color_by
+    } else {
+      spider_group <- sample_spider
+    }
+    
+    # centroids
+    centroids <- dsites %>%
+      dplyr::group_by(.data[[spider_group]]) %>%
+      dplyr::summarise(
+        cx = mean(.data[[x_axis_name]]),
+        cy = mean(.data[[y_axis_name]]),
+        .groups = "drop"
+      )
+    
+    spider_df <- merge(
+      dsites,
+      centroids,
+      by.x = spider_group,
+      by.y = spider_group
+    )
+    
+    # Segments point
+    plot <- plot +
+      geom_segment(
+        data = spider_df,
+        aes_string(
+          x = x_axis_name,
+          y = y_axis_name,
+          xend = "cx",
+          yend = "cy",
+          colour = spider_group
+        ),
+        alpha = 0.5 * opacity,
+        linewidth = 0.4,
+        inherit.aes = FALSE
+      )
   }
 
   ##### Plot sample points  #####

--- a/R/amp_ordinate.R
+++ b/R/amp_ordinate.R
@@ -35,7 +35,7 @@
 #' @param sample_label_size Sample labels text size. (\emph{default:} \code{4})
 #' @param sample_label_segment_color Sample labels repel-segment color. (\emph{default:} \code{"black"})
 #' @param sample_shape_by Shape sample points by a variable in the metadata.
-#' @param sample_spider Connect the sample points to their group centroid with lines to create a spider plot, split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to draw the spider plot based on the variable in \code{sample_color_by}. (\emph{default:} \code{FALSE}) \note{Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).}
+#' @param sample_spider Connect the sample points to their group centroid with lines to create a spider plot, split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to draw the spider plot based on the variable in \code{sample_color_by}. (\emph{default:} \code{FALSE}) Note: Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).
 #' @param sample_colorframe Frame the sample points with a polygon by a variable in the metadata split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to frame the points colored by \code{sample_color_by}. (\emph{default:} \code{FALSE})
 #' @param sample_colorframe_label Label by a variable in the metadata.
 #' @param sample_colorframe_label_size Size of the color frame labels. (\emph{default:} \code{3})

--- a/man/amp_ordinate.Rd
+++ b/man/amp_ordinate.Rd
@@ -17,6 +17,7 @@ amp_ordinate(
   sample_color_by = NULL,
   sample_color_order = NULL,
   sample_shape_by = NULL,
+  sample_spider = FALSE,
   sample_colorframe = FALSE,
   sample_colorframe_label = NULL,
   sample_colorframe_label_size = 3,
@@ -94,6 +95,8 @@ Default is \code{bray}.}
 \item{sample_color_order}{Order the colors in \code{sample_color_by} by the order in a vector.}
 
 \item{sample_shape_by}{Shape sample points by a variable in the metadata.}
+
+\item{sample_spider}{Connect the sample points to their group centroid with lines to create a spider plot, split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to draw the spider plot based on the variable in \code{sample_color_by}. (\emph{default:} \code{FALSE}) \note{Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).}}
 
 \item{sample_colorframe}{Frame the sample points with a polygon by a variable in the metadata split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to frame the points colored by \code{sample_color_by}. (\emph{default:} \code{FALSE})}
 

--- a/man/amp_ordinate.Rd
+++ b/man/amp_ordinate.Rd
@@ -96,7 +96,7 @@ Default is \code{bray}.}
 
 \item{sample_shape_by}{Shape sample points by a variable in the metadata.}
 
-\item{sample_spider}{Connect the sample points to their group centroid with lines to create a spider plot, split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to draw the spider plot based on the variable in \code{sample_color_by}. (\emph{default:} \code{FALSE}) \note{Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).}}
+\item{sample_spider}{Connect the sample points to their group centroid with lines to create a spider plot, split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to draw the spider plot based on the variable in \code{sample_color_by}. (\emph{default:} \code{FALSE}) Note: Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).}
 
 \item{sample_colorframe}{Frame the sample points with a polygon by a variable in the metadata split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to frame the points colored by \code{sample_color_by}. (\emph{default:} \code{FALSE})}
 

--- a/man/amp_ordinate.Rd
+++ b/man/amp_ordinate.Rd
@@ -96,7 +96,7 @@ Default is \code{bray}.}
 
 \item{sample_shape_by}{Shape sample points by a variable in the metadata.}
 
-\item{sample_spider}{Connect the sample points to their group centroid with lines to create a spider plot, split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to draw the spider plot based on the variable in \code{sample_color_by}. (\emph{default:} \code{FALSE}) Note: Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).}
+\item{sample_spider}{Connect the sample points to their group centroid with lines to create a spider plot, split by the grouping variable defined by \code{sample_color_by}, or overridden by \code{sample_colorframe} if provided, or simply \code{TRUE} to draw the spider plot based on the same grouping logic. (\emph{default:} \code{FALSE}) Note: Arithmetic mean centroids are mathematically rigorous for Euclidean-based ordinations (PCA, PCoA, RDA), but serve as approximations or are less suitable for others methods (NMDS, CCA, CA).}
 
 \item{sample_colorframe}{Frame the sample points with a polygon by a variable in the metadata split by the variable defined by \code{sample_color_by}, or simply \code{TRUE} to frame the points colored by \code{sample_color_by}. (\emph{default:} \code{FALSE})}
 


### PR DESCRIPTION
I think it would be great to add the ability to create spider plots in amp_ordinate. It allows samples to be connected to their group centroids, based on a variable (kind of like ordispider from vegan).

Small fix #183 

I tested both function (amp_ordinate and amp_heatmap) and everything seems to be working properly.